### PR TITLE
feat: support multiple WebSocket sub-protocols in MQTT connection

### DIFF
--- a/mqtt.js
+++ b/mqtt.js
@@ -4726,14 +4726,19 @@ function createWebSocket (client, url, opts) {
 }
 
 function createBrowserWebSocket (client, opts) {
-  const websocketSubProtocol =
-  (opts.protocolId === 'MQIsdp') && (opts.protocolVersion === 3)
+  let websocketSubProtocols = [];
+
+  if (opts != undefined && opts.wsOptions !== undefined && opts.wsOptions.protocol !== undefined) {
+    websocketSubProtocols = opts.wsOptions.protocol.split(',');
+  }
+  
+  websocketSubProtocols.push((opts.protocolId === 'MQIsdp') && (opts.protocolVersion === 3)
     ? 'mqttv3.1'
-    : 'mqtt'
+    : 'mqtt');
 
   const url = buildUrl(opts, client)
   /* global WebSocket */
-  const socket = new WebSocket(url, [websocketSubProtocol])
+  const socket = new WebSocket(url, websocketSubProtocols)
   socket.binaryType = 'arraybuffer'
   return socket
 }


### PR DESCRIPTION
Allow custom WebSocket sub-protocols to be specified via opts.wsOptions.protocol (comma-separated). Custom protocols are now included alongside the default MQTT protocol during WebSocket connection negotiation.

- Changed from single protocol to array of protocols
- Parse custom protocols from opts.wsOptions.protocol if provided
- Maintain backward compatibility by always including MQTT protocol